### PR TITLE
Refactor scripts, add Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN pip install git+https://github.com/Blazemeter/taurus@master
 
 # copy configs
 COPY ./squid/* /etc/squid/
+COPY ./scripts/* /usr/local/bin/
 COPY ./init.sh /usr/bin/
 
 ENTRYPOINT  init.sh && /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,17 @@ FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends apt-utils
+RUN apt-get update --fix-missing && apt-get install -y --no-install-recommends apt-utils software-properties-common
 
-RUN apt-get -y install --no-install-recommends atop zip psmisc imagemagick iproute2\ 
+RUN apt-get -y install --no-install-recommends atop zip psmisc imagemagick iproute2\
  && apt-get -y install --no-install-recommends iputils-ping iptables aptitude squid\
- && apt-get -y install --no-install-recommends screen build-essential default-jdk git\
+ && apt-get -y install --no-install-recommends screen build-essential git\
  && apt-get -y install --no-install-recommends mc traceroute vim wget apache2-utils nano\
  && apt-get -y install --no-install-recommends net-tools lynx less telnet python-pip python-dev\
+ && add-apt-repository -y ppa:webupd8team/java\
+ && apt update\
+ && echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections\
+ && apt-get install -y oracle-java8-installer\
  && apt-get clean
 
 RUN pip install pip setuptools wheel

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+NAME=taurus-proxy
+CWD=$(shell pwd)
+TAURUS_DIR=$(abspath $(CWD)/../taurus)
+
+.PHONY: build
+
+build:
+	docker build -t $(NAME) .
+
+run:
+	docker run --privileged -it -v $(TAURUS_DIR):/bzt $(NAME)

--- a/init.sh
+++ b/init.sh
@@ -1,5 +1,3 @@
-f="/usr/bin/cy" bash -c 'echo -e "wget yandex.ru --no-check-certificate -q &&  echo \"ok\" || echo \"fail\"" > ${f}; chmod +x ${f}'
-f="/usr/bin/cm" bash -c 'echo -e "wget mail.ru --no-check-certificate -q &&  echo \"ok\" || echo \"fail\"" > ${f}; chmod +x ${f}'
 echo
 /etc/init.d/squid start 2>&1 > /dev/null
 iptables -t nat -A OUTPUT -p tcp -m owner ! --uid-owner proxy --dport 80 -j REDIRECT --to-port 3128 && iptables -t nat -A OUTPUT -p tcp -m owner ! --uid-owner proxy --dport 443 -j REDIRECT --to-port 3128
@@ -11,3 +9,5 @@ echo
 echo "CHECKERS"
 echo "cm: check mail"
 echo "cy: check yandex"
+echo "check-link LINK: check link"
+

--- a/scripts/check-link
+++ b/scripts/check-link
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+wget $1 --no-check-certificate -q &&  echo "ok" || echo "fail"

--- a/scripts/cm
+++ b/scripts/cm
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+wget mail.ru --no-check-certificate -q &&  echo "ok" || echo "fail"

--- a/scripts/cy
+++ b/scripts/cy
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+wget yandex.ru --no-check-certificate -q &&  echo "ok" || echo "fail"


### PR DESCRIPTION
`make build` (or just `make`) can be used for rebuilding image.

`make run` can be used for running container with `../taurus` linked into container's `/bzt` path.